### PR TITLE
Used a PublishSubject to trigger the paging source and switchMap

### DIFF
--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -93,8 +93,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
 
         var dataSize = 0
 
-        disposable.add(viewModel.loadPagedFiles(folder)
-            .subscribeOn(Schedulers.io())
+        disposable.add(viewModel.cachedFileList
                 // Hacky way used to find out how many items are in the list
             .map { pagingData ->
                 pagingData.map { dataSize++; it }
@@ -158,6 +157,8 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
                 { error -> println("Error loading files: ${error.message}") }
             )
         )
+
+        viewModel.setFolderName(folder)
     }
 
     private fun setFileClickEvent(){

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -21,7 +21,6 @@ import com.guillermonegrete.gallery.databinding.FragmentFileDetailsBinding
 import com.guillermonegrete.gallery.files.FilesViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
 class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
@@ -58,13 +57,11 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
     }
 
     private fun setUpViewModel() {
-        val listFlow = viewModel.cachedFileList ?: return
         binding.fileDetailsViewpager.adapter = adapter
 
         val index = arguments?.getInt(FILE_INDEX_KEY) ?: 0
 
-        disposable.add(listFlow
-            .subscribeOn(Schedulers.io())
+        disposable.add(viewModel.cachedFileList
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
                 {


### PR DESCRIPTION
Fixes #22. Following the recommendation of this SO [comment](https://stackoverflow.com/questions/69640274/android-paging-flowable-leaking-viewmodel-and-fragment). Using a `switchMap` fixed the leak while keeping the two fragments. Another solution was to merge the two fragments into one. For a better separation of concerns, the `switchMap` solution will be used.