### PR TITLE
Fixed last row of the page having a blank space. 

### DIFF
--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -107,7 +107,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
                 .subscribe({ it.forEach { row ->
                     adapter.snapshot().items[row.pos].width = row.size.width
                     adapter.snapshot().items[row.pos].height = row.size.height
-                }}, { error -> Timber.e(error,"Error loading files") }
+                }}, { error -> Timber.e(error,"Error updating rows") }
                 )
         )
 


### PR DESCRIPTION
It was using the incorrect end index when updating the sizes of the row, in the case of AR being too big. Fixes #47.