### PR TITLE
Clear the tag search text when an item is selected.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/AddTagFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/AddTagFragment.kt
@@ -76,6 +76,7 @@ class AddTagFragment: BottomSheetDialogFragment() {
 
             adapter = TagSuggestionsAdapter { tag ->
                 addChip(tagsGroup, tag)
+                if (newTagEdit.text.isNotEmpty()) newTagEdit.setText("")
             }
 
             newTagEdit.setOnEditorActionListener { v, actionId, _ ->


### PR DESCRIPTION
When searching and clicking a tag in the suggestions list, the list removed the filter but the EditText still had the text. Remove the text for consistency with the list.