### PR TITLE
The video controls don't hide automatically.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
     // Exo player
-    def media3_version = "1.1.1"
+    def media3_version = "1.4.1"
     implementation "androidx.media3:media3-exoplayer:$media3_version"
     implementation "androidx.media3:media3-ui:$media3_version"
 

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -278,6 +278,7 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
             if (position == 0.0f){ // New page
                 val pageIndex = viewPager.currentItem
 
+                currentPlayerView?.setControllerVisibilityListener(null as PlayerView.ControllerVisibilityListener?)
                 val player = exoPlayer ?: return@setPageTransformer
                 player.stop()
                 player.seekTo(0)
@@ -289,8 +290,9 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
                 currentPlayerView?.player = null
                 currentPlayerView = playerView
                 playerView.player = player
-                // Controls hidden by default
+                // Disable automatically changing the controls visibility.
                 playerView.controllerAutoShow = false
+                playerView.controllerShowTimeoutMs = 0
                 if(showBars) {
                     playerView.showController()
                 } else {

--- a/app/src/main/res/layout/custom_exo_player_control_view.xml
+++ b/app/src/main/res/layout/custom_exo_player_control_view.xml
@@ -16,7 +16,7 @@
     <View android:id="@id/exo_controls_background"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:background="@color/exo_black_opacity_60"/>
+        android:background="@android:color/transparent"/>
 
     <FrameLayout android:id="@id/exo_bottom_bar"
         android:layout_width="match_parent"


### PR DESCRIPTION
Removed the background dim when the controls were visible. Fixed controls showing if they were hidden when swiping back to a video.

Closes #145.