### PR TITLE
Fixed video resetting when not fully swiping.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsAdapter.kt
@@ -292,6 +292,7 @@ class FileDetailsAdapter: PagingDataAdapter<File, FileDetailsAdapter.ViewHolder>
         override fun bind(file: File) {
             super.bind(file)
             player.controllerAutoShow = showControls
+            player.updatePadding(bottom = if (showControls) bottomInset else 0)
         }
 
         override fun updateLayout() {


### PR DESCRIPTION
Closes #152.

The black frames are still shown, the only way to avoid them is by loading thumbnails of the videos and displaying them but the backend doesn't provide thumbnails yet.