### PR TITLE
Fixed image size not updating when changing the list. (#164)

### DIFF
--- a/app/src/main/java/com/guillermonegrete/gallery/data/File.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/data/File.kt
@@ -42,7 +42,7 @@ class ImageFile(
 ): File(name, width, height, displayWidth, displayHeight, creationDate, lastModified, tags, folder, id){
     // To make testing easier when comparing and simulate a data class
     override fun equals(other: Any?) =
-        if(other is ImageFile) name == other.name && width == other.width && height == other.height else false
+        if(other is ImageFile) name == other.name && displayWidth == other.displayWidth && displayHeight == other.displayHeight else false
 
     override fun hashCode() = javaClass.hashCode()
 }

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesAdapter.kt
@@ -85,6 +85,7 @@ class FilesAdapter(
         private val selectedIcon: ImageView = itemView.findViewById(R.id.selected_icon)
 
         fun bind(item: File){
+            println("Binding item $absoluteAdapterPosition: $item")
             itemView.layoutParams = FrameLayout.LayoutParams(item.displayWidth, item.displayHeight)
             val realPos = absoluteAdapterPosition
             image.setOnClickListener { itemClicked(realPos) }
@@ -145,7 +146,7 @@ class FilesAdapter(
 object FileDiffCallback : DiffUtil.ItemCallback<File>() {
 
     override fun areItemsTheSame(oldItem: File, newItem: File): Boolean {
-        return oldItem.name == newItem.name
+        return oldItem.id == newItem.id
     }
 
     override fun areContentsTheSame(oldItem: File, newItem: File): Boolean {


### PR DESCRIPTION
The problem was that comparing the images didn't take the dimension to display into account.

Closes #134.