### PR TITLE
Added suggestions from the build analyzer.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,14 +47,6 @@ android {
         kotlinCompilerExtensionVersion = "1.4.2"
     }
 
-    sourceSets {
-        main {
-            java {
-                // needed so the nav directions classes are updated, taken from: https://stackoverflow.com/a/62568138/10244759
-                srcDirs += 'build/generated/source/navigation-args'
-            }
-        }
-    }
     namespace 'com.guillermonegrete.gallery'
 }
 
@@ -75,7 +67,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
 
     // Multi dex
-    implementation 'com.android.support:multidex:1.0.3'
+    implementation 'androidx.multidex:multidex:2.0.1'
 
     // Retrofit
     def retrofit_version = "2.9.0"

--- a/app/src/androidTest/java/com/guillermonegrete/gallery/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/guillermonegrete/gallery/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.guillermonegrete.gallery
 
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,10 +15,11 @@ import org.junit.Assert.*
  */
 @RunWith(AndroidJUnit4::class)
 class ExampleInstrumentedTest {
+
     @Test
     fun useAppContext() {
         // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("com.guillermonegrete.gallery", appContext.packageName)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 plugins {
     id("com.google.dagger.hilt.android") version "2.53.1" apply false
-    id 'com.google.devtools.ksp' version '2.0.21-1.0.27' apply false
+    id 'com.google.devtools.ksp' version '2.1.0-1.0.29' apply false
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,11 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.injected.androidTest.leaveApksInstalledAfterRun=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
Disabled jetifier and update the dex dependency to AndroidX. Enabled Gradle configuration cache.
App is no longer uninstalled after running Android tests. Removed use of deprecated instrumentation test classes. Updated KSP.
Removed navigation args directory configuration that was creating problems with duplicated generated files.