### PR TITLE
Bugfix/#182 wrong sort all files

### DIFF
--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
@@ -23,14 +23,12 @@ class FilesViewModel @Inject constructor(
     private val settings: SettingsRepository
 ): ViewModel() {
 
-    private val defaultFilter: String = "${SortField.DEFAULT.field},${Order.DEFAULT.oder}"
-
     val openDetails: Subject<Int> = PublishSubject.create()
     val updateRows: Subject<List<UpdatedRow>> = PublishSubject.create()
 
     private val folderName: Subject<Folder> = PublishSubject.create()
-    private val filter: Subject<String> = BehaviorSubject.createDefault(defaultFilter)
-    private val tag: Subject<Long> = BehaviorSubject.createDefault(0L)
+    private val filter: BehaviorSubject<ListFilter> = BehaviorSubject.createDefault(ListFilter())
+    private val tag: BehaviorSubject<Long> = BehaviorSubject.createDefault(0L)
     private val forceUpdate: Subject<Boolean> = BehaviorSubject.createDefault(true)
 
     /**
@@ -55,7 +53,7 @@ class FilesViewModel @Inject constructor(
             folderName.distinctUntilChanged().switchMap { folder ->
                 forceUpdate.switchMap {
                     dataSize = 0
-                    val finalFilter = filter.ifEmpty { defaultFilter }
+                    val finalFilter = "${filter.sortType},${filter.order}"
                     filesRepository.getPagedFiles(folder, tagId, finalFilter).toObservable()
                 }
             }
@@ -133,12 +131,20 @@ class FilesViewModel @Inject constructor(
         folderId = folder.id
     }
 
-    fun setFilter(filterBy: String){
+    fun setFilter(filterBy: ListFilter){
         filter.onNext(filterBy)
+    }
+
+    fun getFilter(): ListFilter? {
+        return filter.value
     }
 
     fun setTag(tagId: Long){
         tag.onNext(tagId)
+    }
+
+    fun getTag(): Long? {
+        return tag.value
     }
 
     fun setNewPos(pos: Int){
@@ -210,4 +216,9 @@ class FilesViewModel @Inject constructor(
 
     data class Size(var width: Int, var height: Int)
     data class UpdatedRow(val pos: Int, val size: Size)
+
+    data class ListFilter(
+        val sortType: String = SortField.DEFAULT.field,
+        val order: String = Order.DEFAULT.oder,
+    )
 }

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -29,9 +29,13 @@ import androidx.navigation.fragment.navArgs
 import androidx.paging.LoadState
 import androidx.viewpager2.widget.ViewPager2
 import com.guillermonegrete.gallery.R
+import com.guillermonegrete.gallery.common.Order
+import com.guillermonegrete.gallery.common.SortingDialog
+import com.guillermonegrete.gallery.data.Folder
 import com.guillermonegrete.gallery.data.Tag
 import com.guillermonegrete.gallery.databinding.FragmentFileDetailsBinding
 import com.guillermonegrete.gallery.files.FilesViewModel
+import com.guillermonegrete.gallery.files.SortField
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -95,6 +99,13 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentFileDetailsBinding.bind(view)
+        // Set the order because it might have changed (e.g. when navigating back from a folder with a different sort)
+        viewModel.setTag(SortingDialog.NO_TAG_ID)
+        val isAllFiles =  args.folder == Folder.NULL_FOLDER
+        if (isAllFiles) {
+            viewModel.setFilter("${SortField.CREATED.field},${Order.DESC.oder}")
+        }
+
         shouldSetIndex = true
 
         adapter = FileDetailsAdapter()

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -202,8 +202,10 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
             if (shouldSetIndex &&
                 state.refresh is LoadState.NotLoading &&
                 state.append is LoadState.NotLoading) {
+                // Try to set the item, if the index is bigger than the item count, the adapter will load more items and the listener will trigger again.
                 viewpager.setCurrentItem(index, false)
-                shouldSetIndex = false
+                // Once the count reaches the index, the item is set. Shouldn't set anymore.
+                if (adapter.itemCount > index) shouldSetIndex = false
             }
         }
     }

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.gallery.files.details
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import android.view.GestureDetector
@@ -82,6 +83,20 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
 
     private var bottomInset = 0
 
+    private var checkedField = SortField.DEFAULT.field
+    private var checkedOrder = Order.DEFAULT.oder
+    private var tagId = SortingDialog.NO_TAG_ID
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        viewModel.getFilter()?.let { filter ->
+            checkedField = filter.sortType
+            checkedOrder = filter.order
+        }
+        viewModel.getTag()?.let { tagId = it }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setFragmentResultListener(AddTagFragment.REQUEST_KEY) { _, result ->
@@ -103,7 +118,8 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
         viewModel.setTag(SortingDialog.NO_TAG_ID)
         val isAllFiles =  args.folder == Folder.NULL_FOLDER
         if (isAllFiles) {
-            viewModel.setFilter("${SortField.CREATED.field},${Order.DESC.oder}")
+            viewModel.setTag(tagId)
+            viewModel.setFilter(FilesViewModel.ListFilter(checkedField, checkedOrder))
         }
 
         shouldSetIndex = true


### PR DESCRIPTION
Closes #182 .

Also, when changing the sort in All Files the sort doesn't get saved to the preferences. The All Files sort is independent of the regular files sort, and by default its sort is Created/Descending, this is done to show the newest items.