### PR TITLE
Feature/#173 horizontal orientation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     ksp "com.google.dagger:dagger-compiler:$dagger_version"
     // Hilt
     implementation("com.google.dagger:hilt-android:$dagger_version")
+    implementation("androidx.hilt:hilt-navigation-fragment:1.2.0")
     ksp("com.google.dagger:hilt-android-compiler:$dagger_version")
     // Hilt testing
     androidTestImplementation "com.google.dagger:hilt-android-testing:$dagger_version"

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -2,7 +2,6 @@ package com.guillermonegrete.gallery.files
 
 import android.content.Context
 import android.os.Bundle
-import android.util.DisplayMetrics
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -131,7 +130,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
             filesList.addOnItemTouchListener(listener)
             dragSelectTouchListener = listener
         }
-        bindViewModel(folder)
+        binding.filesList.post { bindViewModel(folder) }
         setFileClickEvent()
     }
 
@@ -147,7 +146,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         adapter.addLoadStateListener(loadListener)
         val list = binding.filesList
 
-        val width = getScreenWidth()
+        val width = getListWidth()
 
         val layoutManager = GridLayoutManager(context, width)
         list.layoutManager = layoutManager
@@ -161,12 +160,13 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
 
         viewModel.width = width
 
-        disposable.addAll(viewModel.cachedFileList
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(
-                { adapter.submitData(lifecycle, it) },
-                { error -> Timber.e(error,"Error loading files") }
-            ),
+        disposable.addAll(
+            viewModel.cachedFileList
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                    { adapter.submitData(lifecycle, it) },
+                    { error -> Timber.e(error,"Error loading files") }
+                ),
             viewModel.updateRows
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ it.forEach { row ->
@@ -186,9 +186,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
                     { error -> Timber.e(error) }
                 ),
             adapter.onItemLongPress.subscribe(
-                {
-                    dragSelectTouchListener?.startDragSelection(it)
-                },
+                { dragSelectTouchListener?.startDragSelection(it) },
                 { Timber.e(it) }
             ),
             adapter.onItemClick.subscribe(
@@ -245,11 +243,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         if(state is LoadState.Error) Timber.e(state.error, "Error when loading files")
     }
 
-    private fun Fragment.getScreenWidth(): Int{
-        val dm = DisplayMetrics()
-        this.requireActivity().windowManager.defaultDisplay.getMetrics(dm)
-        return dm.widthPixels
-    }
+    private fun Fragment.getListWidth() = binding.filesList.width
 
     private val actionModeCallback = object: ActionMode.Callback {
 

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -196,6 +196,8 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
 
         if (viewModel.width != width) viewModel.setListWidth(width)
         viewModel.setFolderName(folder)
+        // When navigating back to files list, reset the details sheet to hidden
+        viewModel.setSheet(false)
     }
 
     private fun setFileClickEvent(){

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -16,7 +16,6 @@ import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResultListener
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.paging.CombinedLoadStates
@@ -33,6 +32,7 @@ import com.guillermonegrete.gallery.data.source.SettingsRepository
 import com.guillermonegrete.gallery.databinding.FragmentFilesListBinding
 import com.guillermonegrete.gallery.files.details.AddTagFragment
 import com.guillermonegrete.gallery.folders.MainActivity
+import com.guillermonegrete.gallery.utils.hiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -46,7 +46,9 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
     private  var _binding: FragmentFilesListBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: FilesViewModel by hiltNavGraphViewModels(R.id.all_files_dest)
+    private val viewModel: FilesViewModel by hiltNavGraphViewModels {
+        if (isAllFiles) R.id.nav_graph else R.id.files_graph
+    }
     private val args: FilesListFragmentArgs by navArgs()
 
     private val disposable = CompositeDisposable()

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -71,17 +71,18 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         super.onAttach(context)
         adapter = FilesAdapter(viewModel)
 
-        // Reset tags because the ViewModel is shared it may have a previous configuration
-        // Reset in this method instead of onCreateView() to avoid resetting everytime the user navigates back to this fragment (e.g. from details frag)
+        // Set in this method instead of onCreateView() to avoid resetting everytime the user navigates back to this fragment (e.g. from details frag)
         if(isAllFiles) {
-            // Default sort for all files (most recent)
-            checkedField = SortField.CREATED
-            checkedOrder = Order.DESC
+            viewModel.getFilter()?.let {
+                checkedField = SortField.fromField(it.sortType) ?: SortField.DEFAULT
+                checkedOrder = Order.fromOrder(it.order)
+            }
         } else {
             val sorting = preferences.getFileSort()
             checkedField = sorting.field
             checkedOrder = sorting.sort
         }
+        tagId = viewModel.getTag() ?: SortingDialog.NO_TAG_ID
         val newFilter = FilesViewModel.ListFilter(checkedField.field, checkedOrder.oder)
         viewModel.setFilter(newFilter)
     }

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -158,8 +158,6 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         }
         list.adapter = adapter
 
-        viewModel.width = width
-
         disposable.addAll(
             viewModel.cachedFileList
                 .observeOn(AndroidSchedulers.mainThread())
@@ -195,7 +193,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
             )
         )
 
-        viewModel.setListWidth(width)
+        if (viewModel.width != width) viewModel.setListWidth(width)
         viewModel.setFolderName(folder)
     }
 

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -2,7 +2,6 @@ package com.guillermonegrete.gallery.files
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -143,26 +142,6 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         super.onDestroyView()
     }
 
-    private var restoredState: Parcelable? = null
-    private var restoredPos = 0
-
-    override fun onViewStateRestored(savedInstanceState: Bundle?) {
-        super.onViewStateRestored(savedInstanceState)
-        if (savedInstanceState != null) {
-            restoredState = BundleCompat.getParcelable(savedInstanceState, "list_state", Parcelable::class.java)
-            restoredPos = savedInstanceState.getInt("list_pos")
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        val layoutManager = binding.filesList.layoutManager as? GridLayoutManager
-        outState.putParcelable("list_state", layoutManager?.onSaveInstanceState())
-        outState.putInt("list_pos", layoutManager?.findFirstVisibleItemPosition() ?: 0)
-    }
-
-    var restorePosition = false
-
     private fun bindViewModel(folder: Folder){
         adapter.addLoadStateListener(loadListener)
         val list = binding.filesList
@@ -179,11 +158,6 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         }
         list.adapter = adapter
 
-        restorePosition = false
-        if (viewModel.width != width) {
-            restorePosition = true
-            viewModel.refresh()
-        }
         viewModel.width = width
 
         disposable.addAll(
@@ -221,6 +195,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
             )
         )
 
+        viewModel.setListWidth(width)
         viewModel.setFolderName(folder)
     }
 
@@ -267,14 +242,6 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         binding.loadingIcon.isVisible = state is LoadState.Loading
         binding.filesMessageContainer.isVisible = state is LoadState.Error
         if(state is LoadState.Error) Timber.e(state.error, "Error when loading files")
-        if (restorePosition &&
-            loadStates.source.refresh is LoadState.NotLoading &&
-            loadStates.source.append is LoadState.NotLoading) {
-            binding.filesList.layoutManager?.onRestoreInstanceState(restoredState)
-            if (adapter.itemCount > restoredPos) {
-                restorePosition = false
-            }
-        }
     }
 
     private fun Fragment.getListWidth() = binding.filesList.width

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -87,6 +87,24 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         viewModel.setFilter(newFilter)
     }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setFragmentResultListener(SortingDialog.RESULT_KEY) { _, bundle ->
+            val result: SortDialogChecked = BundleCompat.getParcelable(bundle, SortingDialog.SORT_KEY, SortDialogChecked::class.java) ?: return@setFragmentResultListener
+            checkedField = result.field
+            checkedOrder = result.sort
+            tagId = result.tagId
+
+            viewModel.setTag(tagId)
+            val newFilter = FilesViewModel.ListFilter(checkedField.field, checkedOrder.oder)
+            viewModel.setFilter(newFilter)
+            // The sort for All Files is independent from the preference sort
+            if (!isAllFiles) preferences.setFileSort(checkedField.field, checkedOrder.oder)
+            val folder = BundleCompat.getParcelable(requireArguments(), FOLDER_KEY, Folder::class.java) ?: Folder.NULL_FOLDER
+            viewModel.setFolderName(folder)
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentFilesListBinding.bind(view)
@@ -219,20 +237,6 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
         val options = SortField.toDisplayArray(listOf(SortField.FILENAME, SortField.CREATED, SortField.MODIFIED))
         val action = FilesListFragmentDirections.actionFilesToSortingDialog(options, SortDialogChecked(checkedField, checkedOrder, tagId), id)
         findNavController().navigate(action)
-        setFragmentResultListener(SortingDialog.RESULT_KEY) { _, bundle ->
-            val result: SortDialogChecked = BundleCompat.getParcelable(bundle, SortingDialog.SORT_KEY, SortDialogChecked::class.java) ?: return@setFragmentResultListener
-            checkedField = result.field
-            checkedOrder = result.sort
-            tagId = result.tagId
-
-            viewModel.setTag(tagId)
-            val newFilter = FilesViewModel.ListFilter(checkedField.field, checkedOrder.oder)
-            viewModel.setFilter(newFilter)
-            // The sort for All Files is independent from the preference sort
-            if (!isAllFiles) preferences.setFileSort(checkedField.field, checkedOrder.oder)
-            val folder = BundleCompat.getParcelable(requireArguments(), FOLDER_KEY, Folder::class.java) ?: Folder.NULL_FOLDER
-            viewModel.setFolderName(folder)
-        }
     }
 
     companion object{

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesListFragment.kt
@@ -15,8 +15,8 @@ import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResultListener
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.paging.CombinedLoadStates
@@ -46,7 +46,7 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
     private  var _binding: FragmentFilesListBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: FilesViewModel by activityViewModels()
+    private val viewModel: FilesViewModel by hiltNavGraphViewModels(R.id.all_files_dest)
     private val args: FilesListFragmentArgs by navArgs()
 
     private val disposable = CompositeDisposable()
@@ -71,7 +71,6 @@ class FilesListFragment: Fragment(R.layout.fragment_files_list) {
 
         // Reset tags because the ViewModel is shared it may have a previous configuration
         // Reset in this method instead of onCreateView() to avoid resetting everytime the user navigates back to this fragment (e.g. from details frag)
-        viewModel.setTag(SortingDialog.NO_TAG_ID)
         if(isAllFiles) {
             // Default sort for all files (most recent)
             checkedField = SortField.CREATED

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
@@ -72,6 +72,7 @@ class FilesViewModel @Inject constructor(
         this.width = width
         pagingData
     }.map { pagingData ->
+        dataSize = 0
         pagingData.map { dataSize++; it }
     }.map { pagingData ->
         var arSum = 0f

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
@@ -69,10 +69,11 @@ class FilesViewModel @Inject constructor(
 
     // The order in combineLatest() is important here, widthSubject must be first so every time it changes all the emissions of files get reprocessed with the new width
     var cachedFileList = Observable.combineLatest(widthSubject, filesFlow) { width, pagingData ->
-
-        @SuppressLint("CheckResult")
-        pagingData.map { dataSize++; Unit }
-
+        this.width = width
+        pagingData
+    }.map { pagingData ->
+        pagingData.map { dataSize++; it }
+    }.map { pagingData ->
         var arSum = 0f
         val tempList = mutableListOf<File>()
         val tempSizes = mutableListOf<Size>()

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
@@ -1,6 +1,5 @@
 package com.guillermonegrete.gallery.files
 
-import android.annotation.SuppressLint
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.flatMap

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
@@ -43,6 +43,7 @@ class FilesViewModel @Inject constructor(
     val newFilePos: Subject<Int> = PublishSubject.create()
 
     var audioOn = true
+    val detailsState: BehaviorSubject<DetailsUIState> = BehaviorSubject.createDefault(DetailsUIState())
 
     var folderId = -1L
         private set
@@ -169,6 +170,12 @@ class FilesViewModel @Inject constructor(
 
     fun isAutoplayEnabled() = settings.getAutoPlayMode()
 
+    fun setSheet(visible: Boolean) {
+        detailsState.value?.let {
+            detailsState.onNext(it.copy(sheetVisible = visible))
+        }
+    }
+
     @Synchronized
     private fun normalizeHeights(subList: List<Size>, height: Float) {
         var totalWidth = 0
@@ -237,4 +244,6 @@ class FilesViewModel @Inject constructor(
         val sortType: String = SortField.DEFAULT.field,
         val order: String = Order.DEFAULT.oder,
     )
+
+    data class DetailsUIState(val sheetVisible: Boolean = false)
 }

--- a/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/FilesViewModel.kt
@@ -241,8 +241,8 @@ class FilesViewModel @Inject constructor(
     data class UpdatedRow(val pos: Int, val size: Size)
 
     data class ListFilter(
-        val sortType: String = SortField.DEFAULT.field,
-        val order: String = Order.DEFAULT.oder,
+        val sortType: String = SortField.CREATED.field,
+        val order: String = Order.DESC.oder,
     )
 
     data class DetailsUIState(val sheetVisible: Boolean = false)

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsAdapter.kt
@@ -36,7 +36,7 @@ import kotlin.math.abs
 
 class FileDetailsAdapter: PagingDataAdapter<File, FileDetailsAdapter.ViewHolder>(FileDiffCallback){
 
-    val panelTouchSubject: PublishSubject<Boolean> = PublishSubject.create()
+    val panelTouchSubject: PublishSubject<Int> = PublishSubject.create()
 
     val setCoverSubject: PublishSubject<Long> = PublishSubject.create()
 
@@ -98,9 +98,9 @@ class FileDetailsAdapter: PagingDataAdapter<File, FileDetailsAdapter.ViewHolder>
     }
 
     @SuppressLint("NotifyDataSetChanged")
-    fun showSheet() {
-        if(!isSheetVisible) {
-            isSheetVisible = true
+    fun setSheet(visibility: Boolean) {
+        if(visibility != isSheetVisible) {
+            isSheetVisible = visibility
             notifyDataSetChanged()
         }
     }
@@ -145,18 +145,7 @@ class FileDetailsAdapter: PagingDataAdapter<File, FileDetailsAdapter.ViewHolder>
             // Hidden state is not considered because it's not enabled for this bottom sheet
             behaviour.addBottomSheetCallback(object: BottomSheetBehavior.BottomSheetCallback(){
                 override fun onStateChanged(p0: View, p1: Int) {
-                    when(p1){
-                        BottomSheetBehavior.STATE_COLLAPSED -> {
-                            isSheetVisible = false
-                            panelTouchSubject.onNext(false)
-                        }
-                        BottomSheetBehavior.STATE_EXPANDED  -> {
-                            isSheetVisible = true
-                            panelTouchSubject.onNext(false)
-                        }
-                        BottomSheetBehavior.STATE_DRAGGING -> panelTouchSubject.onNext(true)
-                        else -> {}
-                    }
+                    panelTouchSubject.onNext(p1)
                 }
 
                 override fun onSlide(p0: View, p1: Float) {}
@@ -258,8 +247,7 @@ class FileDetailsAdapter: PagingDataAdapter<File, FileDetailsAdapter.ViewHolder>
                 if (abs(diffY) > abs(diffX)) {
                     if (diffY < -SWIPE_THRESHOLD && velocityY < -SWIPE_VELOCITY_THRESHOLD) {
                         // State is false, change to true so when it reaches the expanded state the new false state is processed
-                        panelTouchSubject.onNext(true)
-                        behaviour.state = BottomSheetBehavior.STATE_EXPANDED
+                        panelTouchSubject.onNext(BottomSheetBehavior.STATE_EXPANDED)
                         return@setOnSingleFlingListener true
                     }
                 }

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -1,7 +1,6 @@
 package com.guillermonegrete.gallery.files.details
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import android.view.GestureDetector
@@ -16,9 +15,9 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
@@ -51,7 +50,7 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
     private  var _binding: FragmentFileDetailsBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: FilesViewModel by activityViewModels()
+    private val viewModel: FilesViewModel by hiltNavGraphViewModels(R.id.all_files_dest)
     private val args: FileDetailsFragmentArgs by navArgs()
     private var exoPlayer: ExoPlayer? = null
 
@@ -87,18 +86,13 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
     private var checkedOrder = Order.DEFAULT.oder
     private var tagId = SortingDialog.NO_TAG_ID
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         viewModel.getFilter()?.let { filter ->
             checkedField = filter.sortType
             checkedOrder = filter.order
         }
         viewModel.getTag()?.let { tagId = it }
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
         setFragmentResultListener(AddTagFragment.REQUEST_KEY) { _, result ->
             // Instead of using the snapshot list, the recommended approach to update an item is updating a cache source
             // and reloading from there (like a database) as explained here: https://stackoverflow.com/a/63139535/10244759

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -115,7 +115,6 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentFileDetailsBinding.bind(view)
         // Set the order because it might have changed (e.g. when navigating back from a folder with a different sort)
-        viewModel.setTag(SortingDialog.NO_TAG_ID)
         val isAllFiles =  args.folder == Folder.NULL_FOLDER
         if (isAllFiles) {
             viewModel.setTag(tagId)

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -18,7 +18,6 @@ import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
@@ -37,6 +36,7 @@ import com.guillermonegrete.gallery.data.Tag
 import com.guillermonegrete.gallery.databinding.FragmentFileDetailsBinding
 import com.guillermonegrete.gallery.files.FilesViewModel
 import com.guillermonegrete.gallery.files.SortField
+import com.guillermonegrete.gallery.utils.hiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -51,7 +51,9 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
     private  var _binding: FragmentFileDetailsBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: FilesViewModel by hiltNavGraphViewModels(R.id.all_files_dest)
+    private val viewModel: FilesViewModel by hiltNavGraphViewModels {
+        if (isAllFiles) R.id.nav_graph else R.id.files_graph
+    }
     private val args: FileDetailsFragmentArgs by navArgs()
     private var exoPlayer: ExoPlayer? = null
 
@@ -86,6 +88,9 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
     private var checkedField = SortField.DEFAULT.field
     private var checkedOrder = Order.DEFAULT.oder
     private var tagId = SortingDialog.NO_TAG_ID
+
+    private val isAllFiles: Boolean
+        get() = args.folder == Folder.NULL_FOLDER
 
     override fun onAttach(context: Context) {
         super.onAttach(context)

--- a/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/files/details/FileDetailsFragment.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.gallery.files.details
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import android.view.GestureDetector
@@ -86,13 +87,17 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
     private var checkedOrder = Order.DEFAULT.oder
     private var tagId = SortingDialog.NO_TAG_ID
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
         viewModel.getFilter()?.let { filter ->
             checkedField = filter.sortType
             checkedOrder = filter.order
         }
         viewModel.getTag()?.let { tagId = it }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         setFragmentResultListener(AddTagFragment.REQUEST_KEY) { _, result ->
             // Instead of using the snapshot list, the recommended approach to update an item is updating a cache source
             // and reloading from there (like a database) as explained here: https://stackoverflow.com/a/63139535/10244759
@@ -102,7 +107,7 @@ class FileDetailsFragment : Fragment(R.layout.fragment_file_details) {
             adapter.snapshot().items[pos].tags = newTags
             adapter.notifyItemChanged(pos)
         }
-        index = args.fileIndex
+        if (savedInstanceState == null) index = args.fileIndex
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/FoldersListFragment.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/FoldersListFragment.kt
@@ -4,6 +4,7 @@ import android.app.SearchManager
 import android.content.Context
 import android.os.Bundle
 import android.view.*
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.SearchView
@@ -226,6 +227,7 @@ class FoldersListFragment: Fragment(R.layout.fragment_folders_list){
         val searchView = menu.findItem(R.id.action_search).actionView as SearchView
         searchView.setSearchableInfo(searchManager.getSearchableInfo(activity?.componentName))
         searchView.maxWidth = Int.MAX_VALUE
+        searchView.imeOptions = searchView.imeOptions or EditorInfo.IME_FLAG_NO_EXTRACT_UI
 
         disposable.add(
             searchView.queryTextChanges()

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
@@ -10,9 +10,9 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.updateLayoutParams
-import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
+import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.navigation.NavigationBarView
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
@@ -36,35 +36,7 @@ class MainActivity : AppCompatActivity() {
         val navigationView = binding.mainNavView
 
         when(navigationView) {
-            is NavigationBarView -> {
-                navigationView.setOnItemSelectedListener {
-                    val currentDest = navController.currentDestination?.id
-
-                    if (currentDest == R.id.files_fragment_dest &&
-                        it.itemId == R.id.all_files_dest) {
-                        val builder = NavOptions.Builder().setRestoreState(true)
-                        builder.setPopUpTo(
-                            R.id.folders_fragment_dest,
-                            inclusive = true,
-                            saveState = true
-                        )
-                        navController.navigate(it.itemId, null, builder.build())
-                    } else if (currentDest == R.id.files_fragment_dest &&
-                        it.itemId == R.id.folders_fragment_dest) {
-                        val builder = NavOptions.Builder().setRestoreState(true)
-                        builder.setPopUpTo(
-                            R.id.all_files_dest,
-                            inclusive = true,
-                            saveState = true
-                        )
-                        navController.navigate(it.itemId, null, builder.build())
-                    } else {
-                        NavigationUI.onNavDestinationSelected(it, navController)
-                    }
-                    return@setOnItemSelectedListener true
-                }
-                navigationView.setOnItemReselectedListener {}
-            }
+            is NavigationBarView -> navigationView.setupWithNavController(navController)
             is NavigationView -> NavigationUI.setupWithNavController(navigationView, navController)
         }
 
@@ -74,6 +46,13 @@ class MainActivity : AppCompatActivity() {
                 // Keep the bar hidden when navigating to the files list from details
                 R.id.files_fragment_dest -> navController.previousBackStackEntry?.destination?.id == R.id.file_details_dest
                 else -> false
+            }
+
+            if(destination.id == R.id.files_fragment_dest) {
+                when(navigationView) {
+                    is NavigationBarView -> navigationView.menu.findItem(R.id.folders_fragment_dest).isChecked = true
+                    is NavigationView -> navigationView.menu.findItem(R.id.folders_fragment_dest).isChecked = true
+                }
             }
         }
 

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
@@ -2,10 +2,14 @@ package com.guillermonegrete.gallery.folders
 
 import android.graphics.Color
 import android.os.Bundle
+import android.view.ViewGroup
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
+import androidx.core.view.updateLayoutParams
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupWithNavController
@@ -50,6 +54,19 @@ class MainActivity : AppCompatActivity() {
                     is NavigationView -> navigationView.menu.findItem(R.id.folders_fragment_dest).isChecked = true
                 }
             }
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+            var nv = binding.landscapeLayout
+            if (nv != null) {
+                navigationView.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    leftMargin = insets.left
+                    topMargin = insets.top
+                }
+            }
+
+            windowInsets
         }
     }
 

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
@@ -10,15 +10,19 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.updateLayoutParams
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationBarView
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
 import com.guillermonegrete.gallery.R
 import com.guillermonegrete.gallery.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -36,7 +40,27 @@ class MainActivity : AppCompatActivity() {
         val navigationView = binding.mainNavView
 
         when(navigationView) {
-            is NavigationBarView -> navigationView.setupWithNavController(navController)
+            is NavigationBarView -> {
+                navigationView.setOnItemSelectedListener {
+                    val currentDest = navController.currentDestination?.id
+                    Timber.d("Current: $currentDest, target: ${it.itemId}")
+                    Timber.d("All files: ${R.id.all_files_dest}, files frag: ${R.id.files_fragment_dest}")
+
+                    if (currentDest == R.id.files_fragment_dest &&
+                        it.itemId == R.id.all_files_dest) {
+                        val builder = NavOptions.Builder().setRestoreState(true)
+                        builder.setPopUpTo(
+                            navController.graph.findStartDestination().id,
+                            inclusive = true,
+                            saveState = true
+                        )
+                        navController.navigate(it.itemId, null, builder.build())
+                    } else {
+                        NavigationUI.onNavDestinationSelected(it, navController)
+                    }
+                    return@setOnItemSelectedListener true
+                }
+            }
             is NavigationView -> NavigationUI.setupWithNavController(navigationView, navController)
         }
 
@@ -46,13 +70,6 @@ class MainActivity : AppCompatActivity() {
                 // Keep the bar hidden when navigating to the files list from details
                 R.id.files_fragment_dest -> navController.previousBackStackEntry?.destination?.id == R.id.file_details_dest
                 else -> false
-            }
-
-            if(destination.id == R.id.files_fragment_dest) {
-                when(navigationView) {
-                    is NavigationBarView -> navigationView.menu.findItem(R.id.folders_fragment_dest).isChecked = true
-                    is NavigationView -> navigationView.menu.findItem(R.id.folders_fragment_dest).isChecked = true
-                }
             }
         }
 

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
@@ -14,15 +14,12 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
-import androidx.navigation.ui.setupWithNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationBarView
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
 import com.guillermonegrete.gallery.R
 import com.guillermonegrete.gallery.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
-import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -43,8 +40,6 @@ class MainActivity : AppCompatActivity() {
             is NavigationBarView -> {
                 navigationView.setOnItemSelectedListener {
                     val currentDest = navController.currentDestination?.id
-                    Timber.d("Current: $currentDest, target: ${it.itemId}")
-                    Timber.d("All files: ${R.id.all_files_dest}, files frag: ${R.id.files_fragment_dest}")
 
                     if (currentDest == R.id.files_fragment_dest &&
                         it.itemId == R.id.all_files_dest) {

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
@@ -2,45 +2,59 @@ package com.guillermonegrete.gallery.folders
 
 import android.graphics.Color
 import android.os.Bundle
-import android.view.View
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isGone
 import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupWithNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationBarView
+import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
 import com.guillermonegrete.gallery.R
+import com.guillermonegrete.gallery.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : AppCompatActivity(R.layout.activity_main){
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(navigationBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         val navController = navHostFragment.navController
-        val bottomNavigationView = findViewById<BottomNavigationView>(R.id.main_bottom_nav)
-        bottomNavigationView.setupWithNavController(navController)
+        val navigationView = binding.mainNavView
+
+        when(navigationView) {
+            is NavigationBarView -> navigationView.setupWithNavController(navController)
+            is NavigationView -> NavigationUI.setupWithNavController(navigationView, navController)
+        }
 
         navController.addOnDestinationChangedListener { _, destination, _ ->
-            bottomNavigationView.isGone = when (destination.id) {
+            navigationView.isGone = when (destination.id) {
                 R.id.file_details_dest, R.id.addTagFragment -> true
                 // Keep the bar hidden when navigating to the files list from details
                 R.id.files_fragment_dest -> navController.previousBackStackEntry?.destination?.id == R.id.file_details_dest
                 else -> false
             }
 
-            if(destination.id == R.id.files_fragment_dest)
-                bottomNavigationView.menu.findItem(R.id.folders_fragment_dest).isChecked = true
+            if(destination.id == R.id.files_fragment_dest) {
+                when(navigationView) {
+                    is NavigationBarView -> navigationView.menu.findItem(R.id.folders_fragment_dest).isChecked = true
+                    is NavigationView -> navigationView.menu.findItem(R.id.folders_fragment_dest).isChecked = true
+                }
+            }
         }
     }
 
     fun showSnackBar(message: String) {
-        val navBar = findViewById<View>(R.id.main_bottom_nav)
+        val navBar = binding.mainNavView
         val snackBar = Snackbar.make(navBar, message, Snackbar.LENGTH_SHORT)
         snackBar.setAnchorView(navBar)
         snackBar.show()

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/MainActivity.kt
@@ -10,7 +10,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.updateLayoutParams
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
@@ -45,7 +44,16 @@ class MainActivity : AppCompatActivity() {
                         it.itemId == R.id.all_files_dest) {
                         val builder = NavOptions.Builder().setRestoreState(true)
                         builder.setPopUpTo(
-                            navController.graph.findStartDestination().id,
+                            R.id.folders_fragment_dest,
+                            inclusive = true,
+                            saveState = true
+                        )
+                        navController.navigate(it.itemId, null, builder.build())
+                    } else if (currentDest == R.id.files_fragment_dest &&
+                        it.itemId == R.id.folders_fragment_dest) {
+                        val builder = NavOptions.Builder().setRestoreState(true)
+                        builder.setPopUpTo(
+                            R.id.all_files_dest,
                             inclusive = true,
                             saveState = true
                         )
@@ -55,6 +63,7 @@ class MainActivity : AppCompatActivity() {
                     }
                     return@setOnItemSelectedListener true
                 }
+                navigationView.setOnItemReselectedListener {}
             }
             is NavigationView -> NavigationUI.setupWithNavController(navigationView, navController)
         }

--- a/app/src/main/java/com/guillermonegrete/gallery/utils/HiltUtils.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/utils/HiltUtils.kt
@@ -1,0 +1,29 @@
+package com.guillermonegrete.gallery.utils
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.createViewModelLazy
+import androidx.hilt.navigation.HiltViewModelFactory
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.navigation.fragment.findNavController
+
+/**
+ * A modified version of the original hiltNavGraphViewModels but this takes a lambda parameter that returns the nav graph id.
+ */
+inline fun <reified VM : ViewModel> Fragment.hiltNavGraphViewModels(
+    crossinline navGraphId: () -> Int,
+): Lazy<VM> {
+    val backStackEntry by lazy {
+        findNavController().getBackStackEntry(navGraphId())
+    }
+    val storeProducer: () -> ViewModelStore = {
+        backStackEntry.viewModelStore
+    }
+    return createViewModelLazy(
+        VM::class, storeProducer,
+        factoryProducer = {
+            HiltViewModelFactory(requireActivity(), backStackEntry.defaultViewModelProviderFactory)
+        },
+        extrasProducer = { backStackEntry.defaultViewModelCreationExtras }
+    )
+}

--- a/app/src/main/res/layout-w1240dp/activity_main.xml
+++ b/app/src/main/res/layout-w1240dp/activity_main.xml
@@ -13,6 +13,13 @@
         android:orientation="horizontal"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
+        <com.google.android.material.navigation.NavigationView
+            android:id="@+id/main_nav_view"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="false"
+            app:menu="@menu/main_nav_menu"/>
+
         <androidx.fragment.app.FragmentContainerView
             android:name="androidx.navigation.fragment.NavHostFragment"
             android:id="@+id/nav_host_fragment"
@@ -21,12 +28,6 @@
             app:defaultNavHost="true"
             app:navGraph="@navigation/nav_graph"/>
 
-        <com.google.android.material.navigation.NavigationView
-            android:id="@+id/main_nav_view"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:fitsSystemWindows="false"
-            app:menu="@menu/main_nav_menu"/>
     </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-w1240dp/activity_main.xml
+++ b/app/src/main/res/layout-w1240dp/activity_main.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".folders.MainActivity">
+
+    <LinearLayout
+        android:id="@+id/landscape_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.fragment.app.FragmentContainerView
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:id="@+id/nav_host_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:defaultNavHost="true"
+            app:navGraph="@navigation/nav_graph"/>
+
+        <com.google.android.material.navigation.NavigationView
+            android:id="@+id/main_nav_view"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="false"
+            app:menu="@menu/main_nav_menu"/>
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-w600dp/activity_main.xml
+++ b/app/src/main/res/layout-w600dp/activity_main.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".folders.MainActivity">
+
+    <LinearLayout
+        android:id="@+id/landscape_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <com.google.android.material.navigationrail.NavigationRailView
+            android:id="@+id/main_nav_view"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            app:menu="@menu/main_nav_menu"/>
+
+        <androidx.fragment.app.FragmentContainerView
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:id="@+id/nav_host_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:defaultNavHost="true"
+            app:navGraph="@navigation/nav_graph"/>
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-w600dp/activity_main.xml
+++ b/app/src/main/res/layout-w600dp/activity_main.xml
@@ -17,6 +17,7 @@
             android:id="@+id/main_nav_view"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
+            android:fitsSystemWindows="false"
             app:menu="@menu/main_nav_menu"/>
 
         <androidx.fragment.app.FragmentContainerView

--- a/app/src/main/res/layout-w600dp/dialog_file_order_by.xml
+++ b/app/src/main/res/layout-w600dp/dialog_file_order_by.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="8dp"
+    android:paddingHorizontal="16dp"
+    tools:layout_gravity="bottom">
+
+    <Button
+        android:id="@+id/done_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/done"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/sort_by_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/sort_by"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        android:layout_marginVertical="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <RadioGroup
+        android:id="@+id/field_sort"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checkedButton="@+id/radio_button_1"
+        app:layout_constraintTop_toBottomOf="@+id/sort_by_label"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <RadioButton
+            android:id="@+id/by_name"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/name"
+            style="@style/SortDialogRadioButton"/>
+
+        <RadioButton
+            android:id="@+id/by_creation"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/creation_date"
+            style="@style/SortDialogRadioButton" />
+
+        <RadioButton
+            android:id="@+id/by_last_modified"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/last_modified"
+            style="@style/SortDialogRadioButton" />
+
+        <!--        Causes a problem with the backend server-->
+        <!--<RadioButton
+            android:id="@+id/by_type"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="@string/type"
+            style="@style/SortDialogRadioButton" />-->
+    </RadioGroup>
+
+    <TextView
+        android:id="@+id/order_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/order"
+        android:layout_marginBottom="8dp"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/field_sort" />
+
+    <RadioGroup
+        android:id="@+id/order_sort"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checkedButton="@+id/radio_button_1"
+        app:layout_constraintTop_toBottomOf="@+id/order_label"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <RadioButton
+            android:id="@+id/descending_order"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/descending"
+            style="@style/SortDialogRadioButton" />
+
+        <RadioButton
+            android:id="@+id/ascending_order"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/ascending"
+            style="@style/SortDialogRadioButton" />
+
+    </RadioGroup>
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier_radio_groups"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="end"
+        app:constraint_referenced_ids="field_sort,order_sort" />
+
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/chip_scroll"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:paddingBottom="32dp"
+        android:clipToPadding="false"
+        android:layout_marginStart="8dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/done_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/barrier_radio_groups"
+        tools:visibility="visible">
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/tags_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:singleSelection="true"
+            app:layout_constraintTop_toBottomOf="@+id/order_sort">
+
+            <include layout="@layout/choice_chip"
+                android:visibility="gone"
+                tools:visibility="visible"/>
+
+        </com.google.android.material.chip.ChipGroup>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-w600dp/file_details_bottom.xml
+++ b/app/src/main/res/layout-w600dp/file_details_bottom.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Because the nav bar is transparent, the bottom insets should be ignored so the sheet doesn't display behind the  bar-->
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/bottom_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="@style/Widget.Material3.BottomSheet"
+    app:gestureInsetBottomIgnored="true"
+    app:paddingBottomSystemWindowInsets="false"
+    app:behavior_peekHeight="0dp"
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+    tools:layout_gravity="bottom">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_marginTop="16dp"
+            android:contentDescription="@string/image_icon"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/guideline_top"
+            app:srcCompat="@drawable/ic_image_24dp" />
+
+        <TextView
+            android:id="@+id/file_name_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+            app:layout_constraintBottom_toBottomOf="@+id/imageView"
+            app:layout_constraintStart_toEndOf="@+id/imageView"
+            app:layout_constraintTop_toTopOf="@+id/imageView"
+            app:layout_constraintEnd_toStartOf="@id/open_folder_button"
+            tools:text="dummy_file_name.jpg" />
+
+        <TextView
+            android:id="@+id/folder_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="@+id/file_name_text"
+            app:layout_constraintStart_toStartOf="@+id/file_name_text"
+            app:layout_constraintTop_toBottomOf="@+id/file_name_text"
+            tools:text="folder name"
+            tools:visibility="visible" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_top"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_begin="8dp" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_bottom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="file_name_text,folder_text,imageView" />
+
+        <TextView
+            android:id="@+id/file_size"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="@+id/file_name_text"
+            app:layout_constraintStart_toStartOf="@+id/file_name_text"
+            app:layout_constraintTop_toBottomOf="@+id/barrier_bottom"
+            tools:text="1000x500" />
+
+        <TextView
+            android:id="@+id/creation_date"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintStart_toEndOf="@id/dates_barrier"
+            app:layout_constraintTop_toBottomOf="@+id/file_size"
+            tools:text="21 Oct 2021" />
+
+        <TextView
+            android:id="@+id/textView3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/created"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/file_size" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/dates_barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="right"
+            app:constraint_referenced_ids="textView4, textView3" />
+
+        <TextView
+            android:id="@+id/modified_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            app:layout_constraintBottom_toBottomOf="@+id/textView4"
+            app:layout_constraintStart_toEndOf="@id/dates_barrier"
+            app:layout_constraintTop_toTopOf="@+id/textView4"
+            tools:text="22 Oct 2021" />
+
+        <TextView
+            android:id="@+id/textView4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/modified"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView3" />
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/chips_scroll"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:clipToPadding="false"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_max="150dp"
+            app:layout_constraintStart_toEndOf="@id/barrier_end"
+            app:layout_constraintTop_toTopOf="@id/barrier_bottom">
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/tags_chip_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/add_tag_btn"
+                    style="@style/Widget.Material3.Chip.Assist"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/add_tag"
+                    app:chipIcon="@drawable/ic_baseline_add_24"
+                    app:chipIconTint="?colorOnSurface"
+                    app:ensureMinTouchTargetSize="true"
+                    app:textEndPadding="@dimen/chip_text_padding"
+                    app:textStartPadding="@dimen/chip_text_padding" />
+
+                <include
+                    layout="@layout/choice_chip"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+            </com.google.android.material.chip.ChipGroup>
+
+        </androidx.core.widget.NestedScrollView>
+
+        <ImageButton
+            android:id="@+id/open_folder_button"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?android:selectableItemBackground"
+            android:contentDescription="@string/open_folder"
+            android:padding="4dp"
+            android:scaleType="fitCenter"
+            android:visibility="gone"
+            app:layout_constraintEnd_toStartOf="@id/set_cover_btn"
+            app:layout_constraintTop_toTopOf="@+id/open_link_button"
+            app:srcCompat="@drawable/baseline_folder_24"
+            app:tint="?colorOnSurface"
+            tools:visibility="visible" />
+
+        <ImageButton
+            android:id="@+id/set_cover_btn"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginTop="8dp"
+            android:background="?android:selectableItemBackground"
+            android:contentDescription="@string/cover_btn_description"
+            android:padding="8dp"
+            android:scaleType="fitCenter"
+            app:layout_constraintEnd_toStartOf="@+id/open_link_button"
+            app:layout_constraintTop_toTopOf="@id/guideline_top"
+            app:srcCompat="@drawable/ic_baseline_photo_album_24"
+            app:tint="?colorOnSurface" />
+
+        <ImageButton
+            android:id="@+id/open_link_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?android:selectableItemBackground"
+            android:contentDescription="@string/open_in_browser"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:padding="4dp"
+            android:scaleType="fitCenter"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/set_cover_btn"
+            app:srcCompat="@drawable/ic_open_in_browser_black_24dp"
+            app:tint="#2196F3" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_end"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="end"
+            app:constraint_referenced_ids="creation_date,modified_date" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,7 +15,7 @@
         app:navGraph="@navigation/nav_graph"/>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/main_bottom_nav"
+        android:id="@+id/main_nav_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"

--- a/app/src/main/res/layout/dialog_set_server_address.xml
+++ b/app/src/main/res/layout/dialog_set_server_address.xml
@@ -30,9 +30,10 @@
 
     <Button
         android:id="@+id/search_servers_btn"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
+        android:layout_gravity="center_horizontal"
         android:text="@string/search_servers"/>
 
     <com.google.android.material.progressindicator.CircularProgressIndicator

--- a/app/src/main/res/layout/fragment_add_tag.xml
+++ b/app/src/main/res/layout/fragment_add_tag.xml
@@ -27,7 +27,7 @@
                 android:minWidth="48dp"
                 android:minHeight="48dp"
                 android:hint="@string/add_tag_label"
-                android:imeOptions="actionDone"/>
+                android:imeOptions="actionDone|flagNoExtractUi"/>
 
         </com.google.android.material.chip.ChipGroup>
 

--- a/app/src/main/res/navigation/files_list_detail_graph.xml
+++ b/app/src/main/res/navigation/files_list_detail_graph.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation
+    android:id="@+id/all_files_dest"
+    app:startDestination="@id/files_fragment_dest"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+    <fragment
+        android:id="@+id/files_fragment_dest"
+        android:name="com.guillermonegrete.gallery.files.FilesListFragment"
+        android:label="Files list"
+        tools:layout="@layout/fragment_files_list">
+        <action
+            android:id="@+id/open_file_details"
+            app:destination="@id/file_details_dest"/>
+        <action
+            android:id="@+id/action_files_to_sorting_dialog"
+            app:destination="@id/sorting_dialog">
+            <argument
+                android:name="options"
+                app:argType="com.guillermonegrete.gallery.common.Field[]"/>
+            <argument
+                android:name="selections"
+                app:argType="com.guillermonegrete.gallery.common.SortDialogChecked"/>
+            <argument
+                android:name="folder_id"
+                android:defaultValue="0L"
+                app:argType="long"/>
+        </action>
+        <action
+            android:id="@+id/action_files_to_addTagFragment"
+            app:destination="@id/addTagFragment">
+            <argument
+                android:name="file_ids"
+                app:argType="long[]"/>
+            <argument
+                android:name="tags"
+                app:argType="com.guillermonegrete.gallery.data.Tag[]"/>
+        </action>
+        <argument
+            android:name="folder"
+            android:defaultValue="@null"
+            app:argType="com.guillermonegrete.gallery.data.Folder"
+            app:nullable="true" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/file_details_dest"
+        android:name="com.guillermonegrete.gallery.files.details.FileDetailsFragment"
+        android:label="fragment_file_details"
+        tools:layout="@layout/fragment_file_details">
+        <action
+            android:id="@+id/fileDetails_to_files_fragment"
+            app:destination="@id/all_files_dest">
+            <argument
+                android:name="folder"
+                android:defaultValue="@null"
+                app:argType="com.guillermonegrete.gallery.data.Folder"
+                app:nullable="true" />
+        </action>
+        <action
+            android:id="@+id/fileDetails_to_addTagFragment"
+            app:destination="@id/addTagFragment">
+            <argument
+                android:name="file_ids"
+                app:argType="long[]"/>
+            <argument
+                android:name="tags"
+                app:argType="com.guillermonegrete.gallery.data.Tag[]"/>
+        </action>
+        <argument
+            android:name="file_index"
+            app:argType="integer" />
+        <argument
+            android:name="folder"
+            app:argType="com.guillermonegrete.gallery.data.Folder" />
+    </fragment>
+</navigation>

--- a/app/src/main/res/navigation/files_list_detail_graph.xml
+++ b/app/src/main/res/navigation/files_list_detail_graph.xml
@@ -51,7 +51,7 @@
         tools:layout="@layout/fragment_file_details">
         <action
             android:id="@+id/fileDetails_to_files_fragment"
-            app:destination="@id/open_file_details">
+            app:destination="@id/files_graph">
             <argument
                 android:name="folder"
                 android:defaultValue="@null"

--- a/app/src/main/res/navigation/files_list_detail_graph.xml
+++ b/app/src/main/res/navigation/files_list_detail_graph.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation
-    android:id="@+id/all_files_dest"
+    android:id="@+id/files_graph"
     app:startDestination="@id/files_fragment_dest"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -51,7 +51,7 @@
         tools:layout="@layout/fragment_file_details">
         <action
             android:id="@+id/fileDetails_to_files_fragment"
-            app:destination="@id/all_files_dest">
+            app:destination="@id/open_file_details">
             <argument
                 android:name="folder"
                 android:defaultValue="@null"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -5,28 +5,7 @@
     android:id="@+id/nav_graph"
     app:startDestination="@id/folders_fragment_dest">
 
-    <!-- Destination for the bottom tab, can't combine with the files_fragment_dest
-    destination because the bottom tab gets selected when navigating to files_fragment_dest -->
-    <fragment
-        android:id="@+id/all_files_dest"
-        android:name="com.guillermonegrete.gallery.files.FilesListFragment"
-        android:label="Files list"
-        tools:layout="@layout/fragment_files_list">
-        <action
-            android:id="@+id/open_file_details"
-            app:destination="@id/file_details_dest" />
-        <action
-            android:id="@+id/action_files_to_sorting_dialog"
-            app:destination="@id/sorting_dialog" />
-        <action
-            android:id="@+id/action_files_to_addTagFragment"
-            app:destination="@id/addTagFragment" />
-        <argument
-            android:name="folder"
-            android:defaultValue="@null"
-            app:argType="com.guillermonegrete.gallery.data.Folder"
-            app:nullable="true" />
-    </fragment>
+    <include app:graph="@navigation/files_list_detail_graph"/>
 
     <fragment
         android:id="@+id/folders_fragment_dest"
@@ -35,51 +14,19 @@
         tools:layout="@layout/fragment_folders_list">
         <action
             android:id="@+id/open_folder"
-            app:destination="@id/files_fragment_dest" />
+            app:destination="@id/all_files_dest">
+            <argument
+                android:name="folder"
+                android:defaultValue="@null"
+                app:argType="com.guillermonegrete.gallery.data.Folder"
+                app:nullable="true" />
+        </action>
         <action
             android:id="@+id/action_folders_fragment_dest_to_serversFragment"
             app:destination="@id/servers_fragment_dest" />
         <action
             android:id="@+id/action_folders_to_sorting_dialog"
             app:destination="@id/sorting_dialog" />
-    </fragment>
-    <fragment
-        android:id="@+id/files_fragment_dest"
-        android:name="com.guillermonegrete.gallery.files.FilesListFragment"
-        android:label="Files list"
-        tools:layout="@layout/fragment_files_list">
-        <action
-            android:id="@+id/open_file_details"
-            app:destination="@id/file_details_dest" />
-        <action
-            android:id="@+id/action_files_to_sorting_dialog"
-            app:destination="@id/sorting_dialog" />
-        <action
-            android:id="@+id/action_files_to_addTagFragment"
-            app:destination="@id/addTagFragment" />
-        <argument
-            android:name="folder"
-            android:defaultValue="@null"
-            app:argType="com.guillermonegrete.gallery.data.Folder"
-            app:nullable="true" />
-    </fragment>
-    <fragment
-        android:id="@+id/file_details_dest"
-        android:name="com.guillermonegrete.gallery.files.details.FileDetailsFragment"
-        android:label="fragment_file_details"
-        tools:layout="@layout/fragment_file_details" >
-        <action
-            android:id="@+id/fileDetails_to_addTagFragment"
-            app:destination="@id/addTagFragment" />
-        <action
-            android:id="@+id/fileDetails_to_files_fragment"
-            app:destination="@id/files_fragment_dest" />
-        <argument
-            android:name="file_index"
-            app:argType="integer"/>
-        <argument
-            android:name="folder"
-            app:argType="com.guillermonegrete.gallery.data.Folder" />
     </fragment>
     <dialog
         android:id="@+id/servers_fragment_dest"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -14,7 +14,7 @@
         tools:layout="@layout/fragment_folders_list">
         <action
             android:id="@+id/open_folder"
-            app:destination="@id/all_files_dest">
+            app:destination="@id/files_graph">
             <argument
                 android:name="folder"
                 android:defaultValue="@null"
@@ -27,6 +27,82 @@
         <action
             android:id="@+id/action_folders_to_sorting_dialog"
             app:destination="@id/sorting_dialog" />
+    </fragment>
+    <fragment
+        android:id="@+id/all_files_dest"
+        android:name="com.guillermonegrete.gallery.files.FilesListFragment"
+        android:label="Files list"
+        tools:layout="@layout/fragment_files_list">
+        <action
+            android:id="@+id/open_file_details"
+            app:destination="@id/file_details_dest">
+            <argument
+                android:name="file_index"
+                app:argType="integer" />
+            <argument
+                android:name="folder"
+                app:argType="com.guillermonegrete.gallery.data.Folder" />
+        </action>
+        <action
+            android:id="@+id/action_files_to_sorting_dialog"
+            app:destination="@id/sorting_dialog">
+            <argument
+                android:name="options"
+                app:argType="com.guillermonegrete.gallery.common.Field[]"/>
+            <argument
+                android:name="selections"
+                app:argType="com.guillermonegrete.gallery.common.SortDialogChecked"/>
+            <argument
+                android:name="folder_id"
+                android:defaultValue="0L"
+                app:argType="long"/>
+        </action>
+        <action
+            android:id="@+id/action_files_to_addTagFragment"
+            app:destination="@id/addTagFragment">
+            <argument
+                android:name="file_ids"
+                app:argType="long[]"/>
+            <argument
+                android:name="tags"
+                app:argType="com.guillermonegrete.gallery.data.Tag[]"/>
+        </action>
+        <argument
+            android:name="folder"
+            android:defaultValue="@null"
+            app:argType="com.guillermonegrete.gallery.data.Folder"
+            app:nullable="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/file_details_dest"
+        android:name="com.guillermonegrete.gallery.files.details.FileDetailsFragment"
+        android:label="fragment_file_details"
+        tools:layout="@layout/fragment_file_details">
+        <action
+            android:id="@+id/fileDetails_to_files_fragment"
+            app:destination="@id/files_graph">
+            <argument
+                android:name="folder"
+                android:defaultValue="@null"
+                app:argType="com.guillermonegrete.gallery.data.Folder"
+                app:nullable="true" />
+        </action>
+        <action
+            android:id="@+id/fileDetails_to_addTagFragment"
+            app:destination="@id/addTagFragment">
+            <argument
+                android:name="file_ids"
+                app:argType="long[]"/>
+            <argument
+                android:name="tags"
+                app:argType="com.guillermonegrete.gallery.data.Tag[]"/>
+        </action>
+        <argument
+            android:name="file_index"
+            app:argType="integer" />
+        <argument
+            android:name="folder"
+            app:argType="com.guillermonegrete.gallery.data.Folder" />
     </fragment>
     <dialog
         android:id="@+id/servers_fragment_dest"


### PR DESCRIPTION
Closes #173.

- Added different a navigation bar depending on the screen size.
- The files list is properly placed in landscape mode.
- On configuration change, the files list data is reused instead of fetching it from the server again.
- Fixed tag in files resetting when navigating from details, only when viewing a single folder (unrelated to orientation changes).
- Created a navigation subgraph for the files list/details, this way the ViewModel is only shared between those two and destroyed when leaving either. This avoids several problems with configuration from one list retaining and applying to another list (because previously the ViewModel was scoped to the activity), and also caused issues to the applied sort/tags during configuration changes.
- Fixed wrong item position in the details when navigating back after a configuration change.
- Keep state of details sheet and other dialogs (sort, tags) on configuration change.
- Added layouts for the file details and the sorting dialogs in larger widths.
- Fixed sorting dialog not working after a configuration change and had to be reopened.