### PR TITLE
Fixed footer loading when a filter was applied.

### DIFF
--- a/app/src/main/java/com/guillermonegrete/gallery/common/NetworkStateAdapter.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/common/NetworkStateAdapter.kt
@@ -7,6 +7,7 @@ import androidx.paging.LoadState
 import androidx.paging.LoadStateAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.guillermonegrete.gallery.databinding.ItemNetworkStateBinding
+import timber.log.Timber
 
 class NetworkStateAdapter(private val retry: () -> Unit) : LoadStateAdapter<NetworkStateAdapter.ViewHolder>() {
 
@@ -26,6 +27,7 @@ class NetworkStateAdapter(private val retry: () -> Unit) : LoadStateAdapter<Netw
         }
 
         fun bind(loadState: LoadState) = with(binding) {
+            Timber.d("$absoluteAdapterPosition, $bindingAdapterPosition: $loadState")
             progressBar.isVisible = loadState is LoadState.Loading
 
             // Error views

--- a/app/src/main/java/com/guillermonegrete/gallery/data/source/DefaultFilesRepository.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/data/source/DefaultFilesRepository.kt
@@ -11,6 +11,7 @@ import com.guillermonegrete.gallery.data.source.remote.FilesServerAPI
 import com.guillermonegrete.gallery.data.source.remote.FilterTags
 import com.guillermonegrete.gallery.folders.source.FoldersAPI
 import com.guillermonegrete.gallery.folders.source.FoldersPageSource
+import com.guillermonegrete.gallery.folders.source.FOLDER_PAGE_SIZE
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
@@ -25,7 +26,7 @@ class DefaultFilesRepository @Inject constructor(
     }
 
     override fun getPagedFolders(tagIds: List<Long>, query: String?, sort: String?): Flowable<PagingData<Folder>> {
-        return Pager(PagingConfig(pageSize = 20)) {
+        return Pager(PagingConfig(pageSize = FOLDER_PAGE_SIZE)) {
             FoldersPageSource(foldersAPI, query, sort, tagIds.ifEmpty { null })
         }.flowable
     }

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/source/FoldersAPI.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/source/FoldersAPI.kt
@@ -11,7 +11,7 @@ interface FoldersAPI {
         @Query("page") page: Int,
         @Query("query") query: String? = null,
         @Query("sort") sort: String? = null,
-        @Query("size") size: Int = 30,
+        @Query("size") size: Int = FOLDER_PAGE_SIZE,
     ): Single<PagedFolderResponse>
 
     @POST("folders")
@@ -20,7 +20,7 @@ interface FoldersAPI {
         @Query("page") page: Int,
         @Query("query") query: String? = null,
         @Query("sort") sort: String? = null,
-        @Query("size") size: Int = 30,
+        @Query("size") size: Int = FOLDER_PAGE_SIZE,
     ): Single<PagedFolderResponse>
 
     @PATCH("folder/{id}/cover/{fileId}")

--- a/app/src/main/java/com/guillermonegrete/gallery/folders/source/FoldersPageSource.kt
+++ b/app/src/main/java/com/guillermonegrete/gallery/folders/source/FoldersPageSource.kt
@@ -32,7 +32,7 @@ class FoldersPageSource(
         return LoadResult.Page(
             data = items,
             prevKey = if (nextPageNumber > 0) nextPageNumber - 1 else null,
-            nextKey = if (nextPageNumber < response.page.totalItems - 1) nextPageNumber + 1 else null
+            nextKey = if (nextPageNumber < response.page.totalPages - 1) nextPageNumber + 1 else null
         )
     }
 
@@ -43,3 +43,5 @@ class FoldersPageSource(
         }
     }
 }
+
+const val FOLDER_PAGE_SIZE = 30


### PR DESCRIPTION
The root of the issue was that the folders list kept trying to load items because the next key wasn't calculated correctly. The next key should have been null after the last page, but it kept increasing.

Closes #257.